### PR TITLE
Support for elastic search in Tripal V3

### DIFF
--- a/tripal_rest_api.inc
+++ b/tripal_rest_api.inc
@@ -259,9 +259,8 @@ function _tripal_rest_api_elasticsearch_tuning() {
 
 function _tripal_rest_api_elasticsearch_index($data) {
 
-    // Three possibilities in Tripal 3
-    // Full website entities, gene_search, and table
-    // Nodes index is created automatically
+    // Four possibilities in Tripal 3
+    // Full website entities, full website nodes, gene_search, and table
 
     if ($data['mode'] == 'table') {
         // Indexing a single table
@@ -282,11 +281,15 @@ function _tripal_rest_api_elasticsearch_index($data) {
         $index_name = 'gene_search';
     }
 
-    else {
-        // Indexing the whole website for entities
-        $index_type = 'entities';
-        $index_name = 'website';
+    elseif ($data['mode'] == 'nodes') {
+        // Indexing the whole website for nodes
+        $index_type = 'website';
+        $index_name = 'website_nodes';
     } 
+    else {
+        $index_type = 'entities';
+        $index_name = 'website_entities';
+    }
 
     // Add indexing tasks to the queues
     $form_state = array();

--- a/tripal_rest_api.inc
+++ b/tripal_rest_api.inc
@@ -245,7 +245,8 @@ function _tripal_rest_api_elasticsearch_tuning() {
     }
 
     return (object)array(
-        'status' => 'running',
+        'status' => 'ok',
+        'msg' => 'Tuning complete'
     );
 }
 

--- a/tripal_rest_api.inc
+++ b/tripal_rest_api.inc
@@ -323,7 +323,8 @@ function _tripal_rest_api_elasticsearch_index($data) {
     }
 
     return (object)array(
-        'status' => 'running',
+        'status' => 'ok',
+        'msg' => 'Index complete'
     );
 }
 

--- a/tripal_rest_api.inc
+++ b/tripal_rest_api.inc
@@ -227,12 +227,45 @@ function _tripal_rest_api_chado_taxonomic_ranks() {
 }
 
 /**
+ * Callback for setting up the tuning form for elasticsearch
+ *
+ * @param object $data
+ * @return object
+ */
+
+function _tripal_rest_api_elasticsearch_tuning() {
+
+    $form_state = array('values' => array());
+    drupal_form_submit('tripal_elasticsearch_tuning_form', $form_state);
+    if (form_get_errors() != '') {
+        return (object)array(
+            'status' => 'error',
+            'errors' => json_encode(form_get_errors())
+        );
+    }
+
+    return (object)array(
+        'status' => 'running',
+    );
+}
+
+/**
  * Callback for indexing with elasticsearch
  *
  * @param object $data
  * @return object
  */
+
 function _tripal_rest_api_elasticsearch_index($data) {
+
+    // Manage options default values
+    
+    $token_filters = [];    
+    $index_form_url = isset($data['index_form_url']) ? $data['index_form_url'] : '';
+
+    // Three possibilities in Tripal 3
+    // Full website entities, gene_search, and table
+    // Nodes index is created automatically
 
     if ($data['mode'] == 'table') {
         // Indexing a single table
@@ -241,38 +274,44 @@ function _tripal_rest_api_elasticsearch_index($data) {
             return services_error('Missing Chado table name \'table\'', 406);
         }
 
-        $website_or_table = 'database table';
-        $website_base_url = ''; // not used
+        $index_type = 'database';
         $index_name = $data['index_name'];
         $index_table = $data['table'];
-        $tokenizer = $data['tokenizer'];
-    }
-    else {
-        // Indexing the whole website
-        $website_or_table = 'website';
-        $website_base_url = 'http://localhost/';
-        $index_name = 'website';
-        $index_table = ''; // not used
-        $tokenizer = ''; //not used
     }
 
-    if (!isset($data['queues'])) {
-        $data['queues'] = 10;
+    elseif ($data['mode'] == 'gene') {
+        // Gene data search
+
+        $index_type = 'gene_search';
+        $index_name = 'gene_search';
     }
-    $queue_N = $data['queues'];
+
+    else {
+        // Indexing the whole website for entities
+        $index_type = 'entities';
+        $index_name = 'website';
+    } 
 
     // Add indexing tasks to the queues
     $form_state = array();
-    $form_state['values']['queue_number'] = $queue_N;
-    $form_state['values']['website_or_table'] = $website_or_table;
-    $form_state['values']['website_base_url'] = $website_base_url;
+    $form_state['values']['index_type'] = $index_type;
     $form_state['values']['index_name'] = $index_name;
+
+    $form_state['values']['exposed'] = isset($data['exposed']) ? $data['exposed'] : 'False';
+    $form_state['values']['index_form_url'] = isset($data['index_form_url']) ? $data['index_form_url'] : '';
+
+
     if (!empty($index_table)) {
         $form_state['values']['index_table'] = $index_table;
     }
-    if (!empty($tokenizer)) {
+    if (isset($data['tokenizer'])) {
         $form_state['values']['index_settings']['tokenizer'] = $tokenizer;
     }
+    if (isset($data['token_filters'])) {
+        $form_state['values']['index_settings']['token_filters'] = $token_filters;
+    }
+
+    // Fields should be an aray with $field_name => $field_mapping_type
     if (isset($data['fields'])) {
         $form_state['values']['table_fields'] = $data['fields'];
     }
@@ -286,40 +325,9 @@ function _tripal_rest_api_elasticsearch_index($data) {
         );
     }
 
-    if ($data['mode'] == 'table') {
-        // Create the search block
-        $form_state = array();
-        $form_state['values']['index_name'] = $index_name;
-        $form_state['values']['table_name'] = $index_table;
-        $form_state['values']['index_fields'] = array_keys($data['fields']);
-        drupal_form_submit('table_search_interface_building_form_submit', $form_state);
-
-        if (form_get_errors() != '') {
-            return (object)array(
-                'status' => 'error',
-                'errors' => json_encode(form_get_errors())
-            );
-        }
-
-        if (!empty($data['links'])) {
-            $form_state = array();
-            $form_state['values']['search_block'] = $index_name;
-            $form_state['values']['field_wrapper'] = $data['links'];
-            drupal_form_submit('link_results_to_pages_form', $form_state);
-
-            if (form_get_errors() != '') {
-                return (object)array(
-                    'status' => 'error',
-                    'errors' => json_encode(form_get_errors())
-                );
-            }
-        }
-
-        // Clear the cache (needed for search block to show up)
-        drupal_flush_all_caches();
-    }
-
-    return $content;
+    return (object)array(
+        'status' => 'running',
+    );
 }
 
 /**

--- a/tripal_rest_api.inc
+++ b/tripal_rest_api.inc
@@ -227,12 +227,44 @@ function _tripal_rest_api_chado_taxonomic_ranks() {
 }
 
 /**
+ * Callback for setting up the tuning form for elasticsearch
+ *
+ * @param object $data
+ * @return object
+ */
+
+function _tripal_rest_api_elasticsearch_tuning() {
+
+    $form_state = array('values' => array());
+    drupal_form_submit('tripal_elasticsearch_tuning_form', $form_state);
+    if (form_get_errors() != '') {
+        return (object)array(
+            'status' => 'error',
+            'errors' => json_encode(form_get_errors())
+        );
+    }
+}
+
+/**
  * Callback for indexing with elasticsearch
  *
  * @param object $data
  * @return object
  */
+
 function _tripal_rest_api_elasticsearch_index($data) {
+
+    // Manage options default values
+    
+    $tokenizer = '';
+    $token_filter = '';
+
+    
+    $index_form_url = isset($data['index_form_url']) ? $data['index_form_url'] : '';
+
+    // Three possibilities in Tripal 3
+    // Full website entities, gene_search, and table
+    // Nodes index is created automatically
 
     if ($data['mode'] == 'table') {
         // Indexing a single table
@@ -241,32 +273,34 @@ function _tripal_rest_api_elasticsearch_index($data) {
             return services_error('Missing Chado table name \'table\'', 406);
         }
 
-        $website_or_table = 'database table';
-        $website_base_url = ''; // not used
+        $index_type = 'database';
         $index_name = $data['index_name'];
         $index_table = $data['table'];
         $tokenizer = $data['tokenizer'];
     }
-    else {
-        // Indexing the whole website
-        $website_or_table = 'website';
-        $website_base_url = 'http://localhost/';
-        $index_name = 'website';
-        $index_table = ''; // not used
-        $tokenizer = ''; //not used
+
+    elseif ($data['mode'] == 'gene') {
+        // Gene data search
+
+        $index_type = 'gene_search';
+        $index_name = 'gene_search';
     }
 
-    if (!isset($data['queues'])) {
-        $data['queues'] = 10;
-    }
-    $queue_N = $data['queues'];
+    else {
+        // Indexing the whole website for entities
+        $index_type = 'entities';
+        $index_name = 'website';
+    } 
 
     // Add indexing tasks to the queues
     $form_state = array();
-    $form_state['values']['queue_number'] = $queue_N;
-    $form_state['values']['website_or_table'] = $website_or_table;
-    $form_state['values']['website_base_url'] = $website_base_url;
+    $form_state['values']['index_type'] = $index_type;
     $form_state['values']['index_name'] = $index_name;
+
+    $form_state['values']['exposed'] = isset($data['exposed']) ? $data['exposed'] : 'False';
+    $form_state['values']['index_form_url'] = isset($data['index_form_url']) ? $data['index_form_url'] : '';
+
+
     if (!empty($index_table)) {
         $form_state['values']['index_table'] = $index_table;
     }

--- a/tripal_rest_api.info
+++ b/tripal_rest_api.info
@@ -9,3 +9,4 @@ dependencies[] = tripal_feature
 dependencies[] = tripal_analysis
 dependencies[] = tripal_organism
 dependencies[] = services
+dependencies[] = rest_server

--- a/tripal_rest_api.module
+++ b/tripal_rest_api.module
@@ -178,6 +178,16 @@ function tripal_rest_api_services_resources() {
                          'optional' => FALSE,
                      ),
                  ),
+             ),
+            'tune' => array(
+                'help' => t('Tripal entity index tuning for website indexing'),
+                'file' => array('type' => 'inc', 'module' => 'tripal_rest_api', 'name' => 'tripal_rest_api'),
+                'callback' => '_tripal_rest_api_elasticsearch_tuning',
+                'access callback' => 'user_access',
+                'access arguments' => array('access tripal_rest_api elasticsearch'),
+                'access arguments append' => FALSE,
+                'args' => array(
+                 ),
              )
          ),
      ),

--- a/tripal_rest_api.services.inc
+++ b/tripal_rest_api.services.inc
@@ -83,6 +83,9 @@ function tripal_rest_api_default_services_endpoint() {
                 'index' => array(
                     'enabled' => '1',
                     ),
+                'tune' => array(
+                    'enabled' => '1',
+                    ),
                 ),
             ),
         'node' => array(


### PR DESCRIPTION
Elastic search was buggy previously (changes in the name of the form)
Added support for entity indexing (basically website indexing)
Added support for node indexing (useless unless legacy modules, maybe?)
Added support for gene_search (no idea how it works, but it's in the elasticsearch module)
Fixes for table indexing

Added function 'tune', required for entity indexing -> Basic support, it sets the default priorities

Removed the block creation part (part of it was non-functional, + it's UI managing, not really fit for the API)
